### PR TITLE
Add Gatsby and Metamask integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # dAPP-sample
+
+## Installation
+
+To install the dependencies, run the following command:
+
+```bash
+npm install
+```
+
+## Running the dApp
+
+To run the dApp, use the following command:
+
+```bash
+npm start
+```
+
+## Connecting to Metamask
+
+To connect to Metamask, follow these steps:
+
+1. Install Metamask extension in your browser.
+2. Open the dApp in your browser.
+3. Click on the "Connect to Metamask" button.
+4. Approve the connection request in the Metamask popup.
+5. Your account address will be displayed on the page.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  siteMetadata: {
+    title: 'dAPP-sample',
+  },
+  plugins: [
+    'gatsby-plugin-react-helmet',
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'src',
+        path: `${__dirname}/src/`,
+      },
+    },
+    'gatsby-transformer-remark',
+  ],
+};

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,29 @@
+exports.createPages = async ({ actions, graphql, reporter }) => {
+  const { createPage } = actions;
+  const result = await graphql(`
+    {
+      allMarkdownRemark {
+        edges {
+          node {
+            frontmatter {
+              path
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  if (result.errors) {
+    reporter.panicOnBuild('Error while running GraphQL query.');
+    return;
+  }
+
+  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+    createPage({
+      path: node.frontmatter.path,
+      component: require.resolve('./src/templates/blogTemplate.js'),
+      context: {},
+    });
+  });
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { graphql } from 'gatsby';
+import { connectToMetamask } from '../utils/web3';
+
+const IndexPage = ({ data }) => {
+  const [account, setAccount] = useState(null);
+
+  const handleConnect = async () => {
+    const connectedAccount = await connectToMetamask();
+    setAccount(connectedAccount);
+  };
+
+  return (
+    <div>
+      <h1>Welcome to the dApp</h1>
+      <button onClick={handleConnect}>Connect to Metamask</button>
+      {account && <p>Connected account: {account}</p>}
+      <div>
+        <h2>Data fetched at build time:</h2>
+        <p>{data.site.siteMetadata.title}</p>
+      </div>
+    </div>
+  );
+};
+
+export const query = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`;
+
+export default IndexPage;

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,0 +1,20 @@
+import Web3 from 'web3';
+
+const connectToMetamask = async () => {
+  if (window.ethereum) {
+    try {
+      await window.ethereum.request({ method: 'eth_requestAccounts' });
+      const web3 = new Web3(window.ethereum);
+      const accounts = await web3.eth.getAccounts();
+      return accounts[0];
+    } catch (error) {
+      console.error("User denied account access");
+      return null;
+    }
+  } else {
+    console.error("Metamask not detected");
+    return null;
+  }
+};
+
+export { connectToMetamask };


### PR DESCRIPTION
Add Gatsby integration and Metamask connection to the dApp.

* **README.md**
  - Add instructions on how to install dependencies, run the dApp, and connect to Metamask.

* **src/utils/web3.js**
  - Import `Web3` from `web3` library.
  - Create a function `connectToMetamask` to handle Metamask connection.
  - Export the `connectToMetamask` function.

* **src/pages/index.js**
  - Import `connectToMetamask` from `src/utils/web3.js`.
  - Add a button to connect to Metamask and display the connected account address.
  - Use Gatsby's static site generation features and GraphQL for fetching data at build time.

* **gatsby-config.js**
  - Add Gatsby configuration settings.

* **gatsby-node.js**
  - Add Gatsby node settings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/carlxaeron/dAPP-sample/pull/1?shareId=3e4ed6b8-05b4-464f-bd7f-8bcc1629c6cc).